### PR TITLE
Configure static ip

### DIFF
--- a/ansible/inventory/host_vars/example.org.yml
+++ b/ansible/inventory/host_vars/example.org.yml
@@ -1,5 +1,11 @@
 ansible_user: ansible
 
+configure_static_ip: false
+
 interface:
   name: enp35s0
   ip: 1.2.3.4
+  # The following variables are only required if configure_static_ip is true
+  gateway: 1.2.3.4
+  netmask: 255.255.255.0
+  dns: 1.1.1.1

--- a/ansible/roles/proxmox-initial/handlers/main.yml
+++ b/ansible/roles/proxmox-initial/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: Restart networking
+  become: true
+  service:
+    name: networking
+    state: restarted

--- a/ansible/roles/proxmox-initial/tasks/main.yml
+++ b/ansible/roles/proxmox-initial/tasks/main.yml
@@ -16,6 +16,18 @@
     upgrade: yes
     update_cache: yes
 
+- name: Configure the chosen IP address to be static
+  become: true
+  template:
+    src: etc/network/interfaces
+    dest: /etc/network/interfaces
+  when: configure_static_ip == true
+  notify:
+    - Restart networking
+
+- name: Ensure the static IP address config has been applied
+  meta: flush_handlers
+
 # https://gist.github.com/rothgar/8793800
 - name: Template /etc/hosts file
   become: true

--- a/ansible/roles/proxmox-initial/templates/etc/network/interfaces
+++ b/ansible/roles/proxmox-initial/templates/etc/network/interfaces
@@ -16,5 +16,5 @@ iface {{ interface.name }} inet static
     dns-nameservers {{ interface.dns }}
 
 # This is an autoconfigured IPv6 interface
-# NOTICE: The IPv6 interface has been disabled because of problems with ifupdown2 and auto-IPv6 configurations
-# iface {{ interface.name }} inet6 auto
+# NOTICE: The IPv6 interface has been set to manual because of problems with ifupdown2 and auto-IPv6 configurations
+iface {{ interface.name }} inet6 manual

--- a/ansible/roles/proxmox-initial/templates/etc/network/interfaces
+++ b/ansible/roles/proxmox-initial/templates/etc/network/interfaces
@@ -1,0 +1,20 @@
+# This file describes the network interfaces available on your system
+# and how to activate them. For more information, see interfaces(5).
+
+source /etc/network/interfaces.d/*
+
+# The loopback network interface
+auto lo
+iface lo inet loopback
+
+# The primary network interface
+auto {{ interface.name }}
+iface {{ interface.name }} inet static
+    address {{ interface.ip }}
+    gateway {{ interface.gateway }}
+    netmask {{ interface.netmask }}
+    dns-nameservers {{ interface.dns }}
+
+# This is an autoconfigured IPv6 interface
+# NOTICE: The IPv6 interface has been disabled because of problems with ifupdown2 and auto-IPv6 configurations
+# iface {{ interface.name }} inet6 auto


### PR DESCRIPTION
This adds an optional (disabled by default) task for setting the configured ip address as static.
Useful for systems running behind a NAT with DHCP, for example development machines in a home network.